### PR TITLE
Tolerate proto deserialize failures — don't crash-loop on a poison record (MAXX-7320)

### DIFF
--- a/src/main/java/com/bbrownsound/flink/formats/proto/registry/confluent/ProtoConfluentFormatOptions.java
+++ b/src/main/java/com/bbrownsound/flink/formats/proto/registry/confluent/ProtoConfluentFormatOptions.java
@@ -133,5 +133,43 @@ public class ProtoConfluentFormatOptions {
                   + "via Flink config options. However, note that Flink options "
                   + "have higher precedence.");
 
+  /** What to do when a record fails to deserialize: "skip" (drop + count) or "fail" (throw). */
+  public static final ConfigOption<String> ON_DESERIALIZE_ERROR =
+      ConfigOptions.key("on-deserialize-error")
+          .stringType()
+          .defaultValue("fail")
+          .withFallbackKeys("on_deserialize_error")
+          .withDescription(
+              "Behavior when a record cannot be deserialized: 'fail' (throw and fail the task — "
+                  + "the default, preserving existing semantics) or 'skip' (log, increment the "
+                  + "numDeserializeErrors metric, optionally route to the dead-letter topic, and "
+                  + "return null so a single poison record cannot crash-loop the job). Set 'skip' "
+                  + "(ideally with 'dead-letter-topic') for resilient pipelines.");
+
+  /** Optional dead-letter topic for records that fail to deserialize. */
+  public static final ConfigOption<String> DEAD_LETTER_TOPIC =
+      ConfigOptions.key("dead-letter-topic")
+          .stringType()
+          .noDefaultValue()
+          .withFallbackKeys("dead_letter_topic")
+          .withDescription(
+              "Optional Kafka topic to which the raw bytes of records that fail to deserialize "
+                  + "are produced (with error metadata in headers). Requires "
+                  + "'dead-letter.properties' to contain at least 'bootstrap.servers'. When unset, "
+                  + "failed records are only logged and counted.");
+
+  /**
+   * Producer properties for the dead-letter topic (bootstrap.servers + security). Forwarded
+   * verbatim to the KafkaProducer; key/value serializers are set to ByteArraySerializer in code.
+   */
+  public static final ConfigOption<Map<String, String>> DEAD_LETTER_PROPERTIES =
+      ConfigOptions.key("dead-letter.properties")
+          .mapType()
+          .noDefaultValue()
+          .withDescription(
+              "Properties forwarded verbatim to the dead-letter KafkaProducer (e.g. "
+                  + "bootstrap.servers, security.protocol, sasl.mechanism, sasl.jaas.config). "
+                  + "Only used when 'dead-letter-topic' is set.");
+
   private ProtoConfluentFormatOptions() {}
 }

--- a/src/main/java/com/bbrownsound/flink/formats/proto/registry/confluent/RegistryProtoFormatFactory.java
+++ b/src/main/java/com/bbrownsound/flink/formats/proto/registry/confluent/RegistryProtoFormatFactory.java
@@ -68,7 +68,10 @@ public class RegistryProtoFormatFactory
             ProtoConfluentFormatOptions.BASIC_AUTH_CREDENTIALS_SOURCE,
             ProtoConfluentFormatOptions.BASIC_AUTH_USER_INFO,
             ProtoConfluentFormatOptions.BEARER_AUTH_CREDENTIALS_SOURCE,
-            ProtoConfluentFormatOptions.BEARER_AUTH_TOKEN)
+            ProtoConfluentFormatOptions.BEARER_AUTH_TOKEN,
+            ProtoConfluentFormatOptions.ON_DESERIALIZE_ERROR,
+            ProtoConfluentFormatOptions.DEAD_LETTER_TOPIC,
+            ProtoConfluentFormatOptions.DEAD_LETTER_PROPERTIES)
         .collect(Collectors.toSet());
   }
 
@@ -97,6 +100,9 @@ public class RegistryProtoFormatFactory
     options.add(ProtoConfluentFormatOptions.BASIC_AUTH_USER_INFO);
     options.add(ProtoConfluentFormatOptions.BEARER_AUTH_CREDENTIALS_SOURCE);
     options.add(ProtoConfluentFormatOptions.BEARER_AUTH_TOKEN);
+    options.add(ProtoConfluentFormatOptions.ON_DESERIALIZE_ERROR);
+    options.add(ProtoConfluentFormatOptions.DEAD_LETTER_TOPIC);
+    options.add(ProtoConfluentFormatOptions.DEAD_LETTER_PROPERTIES);
     return options;
   }
 

--- a/src/main/java/com/bbrownsound/flink/formats/proto/registry/confluent/config/ProtoConfluentFormatConfig.java
+++ b/src/main/java/com/bbrownsound/flink/formats/proto/registry/confluent/config/ProtoConfluentFormatConfig.java
@@ -28,6 +28,15 @@ public class ProtoConfluentFormatConfig implements Serializable {
   /** Whether this format is used for the key (vs value). */
   public Boolean isKey;
 
+  /** Behavior on deserialize failure: "fail" (default) or "skip". */
+  public String onDeserializeError = "fail";
+
+  /** Optional dead-letter topic for records that fail to deserialize (null = disabled). */
+  public String deadLetterTopic;
+
+  /** Producer properties for the dead-letter topic (bootstrap.servers + security). */
+  private Map<String, String> deadLetterProperties = new HashMap<>();
+
   /** Optional properties passed to Schema Registry client. */
   private Map<String, String> properties;
 
@@ -60,6 +69,13 @@ public class ProtoConfluentFormatConfig implements Serializable {
     schemaRegistryUrl = formatOptions.get(ProtoConfluentFormatOptions.URL);
     topic = formatOptions.get(ProtoConfluentFormatOptions.TOPIC);
     isKey = formatOptions.get(ProtoConfluentFormatOptions.IS_KEY);
+    onDeserializeError = formatOptions.get(ProtoConfluentFormatOptions.ON_DESERIALIZE_ERROR);
+    deadLetterTopic =
+        formatOptions.getOptional(ProtoConfluentFormatOptions.DEAD_LETTER_TOPIC).orElse(null);
+    deadLetterProperties = new HashMap<>();
+    formatOptions
+        .getOptional(ProtoConfluentFormatOptions.DEAD_LETTER_PROPERTIES)
+        .ifPresent(deadLetterProperties::putAll);
 
     properties = RegistryProtoFormatFactory.buildOptionalPropertiesMap(formatOptions);
     if (properties == null) {
@@ -86,5 +102,16 @@ public class ProtoConfluentFormatConfig implements Serializable {
    */
   public Map<String, String> getProperties() {
     return properties == null ? Collections.emptyMap() : new HashMap<>(properties);
+  }
+
+  /**
+   * Returns a copy of the dead-letter producer properties map.
+   *
+   * @return copy of the dead-letter producer properties, never null
+   */
+  public Map<String, String> getDeadLetterProperties() {
+    return deadLetterProperties == null
+        ? Collections.emptyMap()
+        : new HashMap<>(deadLetterProperties);
   }
 }

--- a/src/main/java/com/bbrownsound/flink/formats/proto/registry/confluent/deserialize/ProtoRowDataDeserializationSchema.java
+++ b/src/main/java/com/bbrownsound/flink/formats/proto/registry/confluent/deserialize/ProtoRowDataDeserializationSchema.java
@@ -23,6 +23,15 @@ import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+import org.apache.flink.metrics.Counter;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+
 /**
  * Derived from https://github.com/amstee/flink-proto-confluent (Apache-2.0). See NOTICE in project
  * root.
@@ -43,6 +52,10 @@ public class ProtoRowDataDeserializationSchema implements DeserializationSchema<
   private transient KafkaProtobufDeserializer<DynamicMessage> deserializer;
   private transient Map<Integer, ProtoToRowDataConverters.ProtoToRowDataConverter> converters;
   private transient AtomicLong deserializeCount;
+  /** Counts records that failed to deserialize (exposed as the numDeserializeErrors metric). */
+  private transient Counter deserializeErrors;
+  /** Optional producer for the dead-letter topic; null when DLQ is not configured. */
+  private transient KafkaProducer<byte[], byte[]> deadLetterProducer;
 
   /**
    * Creates a deserialization schema for the given row type and config.
@@ -78,6 +91,21 @@ public class ProtoRowDataDeserializationSchema implements DeserializationSchema<
       this.deserializer.configure(formatConfig.getProperties(), formatConfig.isKey);
       this.converters = new ConcurrentHashMap<>();
       this.deserializeCount = new AtomicLong(0);
+      if (context != null) {
+        this.deserializeErrors = context.getMetricGroup().counter("numDeserializeErrors");
+      }
+
+      final Map<String, String> dlqProps = formatConfig.getDeadLetterProperties();
+      if (formatConfig.deadLetterTopic != null && dlqProps.containsKey("bootstrap.servers")) {
+        final Properties producerProps = new Properties();
+        producerProps.putAll(dlqProps);
+        producerProps.put("key.serializer", ByteArraySerializer.class.getName());
+        producerProps.put("value.serializer", ByteArraySerializer.class.getName());
+        this.deadLetterProducer = new KafkaProducer<>(producerProps);
+        LOG.info(
+            "[proto-confluent] dead-letter producer enabled: topic={}",
+            formatConfig.deadLetterTopic);
+      }
       LOG.debug("[proto-confluent] deserializer.open: client and deserializer initialized");
     }
   }
@@ -151,8 +179,38 @@ public class ProtoRowDataDeserializationSchema implements DeserializationSchema<
               + e.getClass().getSimpleName()
               + ": "
               + e.getMessage());
-      throw new IOException("Proto-confluent deserialize failed: " + e.getMessage(), e);
+      if (deserializeErrors != null) {
+        deserializeErrors.inc();
+      }
+      if (deadLetterProducer != null) {
+        try {
+          final ProducerRecord<byte[], byte[]> dlqRecord =
+              new ProducerRecord<>(formatConfig.deadLetterTopic, null, message);
+          dlqRecord
+              .headers()
+              .add(new RecordHeader("error.class", utf8(e.getClass().getName())))
+              .add(new RecordHeader("error.message", utf8(String.valueOf(e.getMessage()))))
+              .add(new RecordHeader("source.topic", utf8(String.valueOf(formatConfig.topic))));
+          deadLetterProducer.send(dlqRecord);
+        } catch (Exception dlqEx) {
+          LOG.error(
+              "[proto-confluent] failed to produce to dead-letter topic {}",
+              formatConfig.deadLetterTopic,
+              dlqEx);
+        }
+      }
+      // Default ("skip"): drop the poison record and keep the job running. A single
+      // unparseable record must not crash-loop the source. Opt into the old fatal behavior
+      // with on-deserialize-error=fail.
+      if ("fail".equalsIgnoreCase(formatConfig.onDeserializeError)) {
+        throw new IOException("Proto-confluent deserialize failed: " + e.getMessage(), e);
+      }
+      return null;
     }
+  }
+
+  private static byte[] utf8(String s) {
+    return s.getBytes(StandardCharsets.UTF_8);
   }
 
   @Override

--- a/src/main/java/com/bbrownsound/flink/formats/proto/registry/confluent/deserialize/ProtoToRowDataConverters.java
+++ b/src/main/java/com/bbrownsound/flink/formats/proto/registry/confluent/deserialize/ProtoToRowDataConverters.java
@@ -272,11 +272,18 @@ public class ProtoToRowDataConverters {
       final Message message = (Message) object;
       final GenericRowData row = new GenericRowData(arity);
       final FieldDescriptor oneofFieldDescriptor = message.getOneofFieldDescriptor(readSchema);
+      // getOneofFieldDescriptor returns null when no case of the oneof is set. The descriptor
+      // may also be absent from fieldConverters when the proto oneof has gained a case that is
+      // not present in the target table schema (schema drift). In either case, leave the row's
+      // columns null instead of dereferencing a null converter (which previously NPE'd and, with
+      // no error tolerance on the Kafka source, crash-looped the whole job on a single record).
       final Pair<ProtoToRowDataConverter, Integer> converters =
-          fieldConverters.get(oneofFieldDescriptor);
-      row.setField(
-          converters.getRight(),
-          converters.getLeft().convert(message.getField(oneofFieldDescriptor)));
+          oneofFieldDescriptor == null ? null : fieldConverters.get(oneofFieldDescriptor);
+      if (converters != null) {
+        row.setField(
+            converters.getRight(),
+            converters.getLeft().convert(message.getField(oneofFieldDescriptor)));
+      }
       return row;
     };
   }

--- a/src/test/java/com/bbrownsound/flink/formats/proto/registry/confluent/deserialize/ProtoRowDataDeserializationSchemaTest.java
+++ b/src/test/java/com/bbrownsound/flink/formats/proto/registry/confluent/deserialize/ProtoRowDataDeserializationSchemaTest.java
@@ -65,6 +65,22 @@ class ProtoRowDataDeserializationSchemaTest {
   }
 
   @Test
+  void deserialize_invalidBytesSkippedWhenOnErrorSkip() throws IOException {
+    RowType rowType =
+        (RowType) ProtoToLogicalType.toLogicalType(TestSimple.SimpleMessage.getDescriptor());
+    Map<String, String> props = Map.of("schema.registry.url", "http://localhost:8081");
+    ProtoConfluentFormatConfig config =
+        new ProtoConfluentFormatConfig("http://localhost:8081", "test-topic", false, props);
+    config.onDeserializeError = "skip";
+    var schema = new ProtoRowDataDeserializationSchema(rowType, null, config);
+    schema.open(null);
+    byte[] invalid = new byte[] {0, 1, 2, 3, 4};
+    // With on-deserialize-error=skip a poison record is dropped (returns null) instead of
+    // throwing, so the Kafka source does not crash-loop. (No dead-letter-topic configured here.)
+    assertNull(schema.deserialize(invalid));
+  }
+
+  @Test
   void open_initializesClientAndDeserializer() {
     RowType rowType =
         (RowType) ProtoToLogicalType.toLogicalType(TestSimple.SimpleMessage.getDescriptor());


### PR DESCRIPTION
## Problem

A single record whose **oneof** case is unset — or is a case **not present in the target table schema** (proto schema drift) — makes `ProtoToRowDataConverters` dereference a `null` converter and throw `NullPointerException`:

```
ProtoToRowDataConverters … getOneofFieldDescriptor → fieldConverters.get(...) == null → .getRight() NPE
ProtoRowDataDeserializationSchema:154 re-throws as IOException (fatal)
```

The Flink Kafka source has **no deserialize error-tolerance**, so one bad record fails the task → the job restarts → re-reads the same offset → NPEs again → **infinite crash loop**. The job makes zero progress and produces nothing, while the operator still reports it "RUNNING".

Observed in prod on SecurityScorecard's `max-measurements-observations` pipeline: a record (`partition 2, offset 46305481348`) wedged the job, so **breach observations silently stopped reaching ClickHouse for weeks** (`evidence` is a ~27-case oneof; an unset/new case triggered it).

## Fix

- **`ProtoToRowDataConverters`** — null-guard the oneof converter: on an unset or unknown (drifted) oneof case, leave the row's columns `null` instead of NPE'ing. *(This alone prevents the crash.)*
- **`ProtoRowDataDeserializationSchema`** — defense-in-depth + observability:
  - `on-deserialize-error` = `fail` (default, unchanged semantics) | `skip` (log, count, return `null` so the source keeps running).
  - `numDeserializeErrors` Flink **metric**.
  - optional **dead-letter topic**: `dead-letter-topic` + `dead-letter.properties` (producer bootstrap/SASL). On failure the raw bytes + error headers (`error.class`, `error.message`, `source.topic`) are produced to the DLQ, then the record is skipped.
  - guard a `null` `InitializationContext` in `open()`.
- Tests for the skip path.

Default behavior is **unchanged** (`fail`) to avoid silently dropping data for existing users; resilient pipelines should set `on-deserialize-error=skip` (ideally with a `dead-letter-topic`).

## Verification

`gradle compileJava` + `gradle test` green on JDK 21 (113 tests; JDK 25 fails unrelated due to JaCoCo 0.8.11 not supporting class-file v69).

## Follow-ups (not in this PR)

- Identify which `evidence` oneof case the poison record sets that the consumer's table schema lacks (recent `factor-schemas` `RawObservation.evidence` additions) — decide whether to **extend the table DDL** to capture it rather than null-skip it.
- Publish this lib as a **pinned, versioned artifact** (it's currently consumed as a `mavenLocal` `1.0.0-SNAPSHOT`, which isn't reproducible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)