### PR TITLE
feat: support explicitly setting message key class + keyed message tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,18 @@ Then in Flink SQL (e.g. `sql-client.sh`), use the format identifier `proto-confl
 'value.proto-confluent.is_key' = 'false'
 ```
 
+To pin an **explicit named** protobuf message class for the key and/or value (instead of the default dynamic, Row-derived schema), set `message-class` on the corresponding format:
+
+```sql
+'key.format' = 'proto-confluent',
+'key.proto-confluent.is_key' = 'true',
+'key.proto-confluent.message-class' = 'com.example.OrderProto$OrderKey',
+'value.format' = 'proto-confluent',
+'value.proto-confluent.message-class' = 'com.example.OrderProto$Order'
+```
+
+`message-class` is role-scoped by `is_key` (key vs value). See [docs/format-options.md](docs/format-options.md) for the full option reference and a complete keyed-sink example.
+
 ## Testing
 
 Tests use JUnit 5 and real components (e.g. Testcontainers for Kafka/Schema Registry); **Mockito is not used**. Coverage includes both unit tests and integration tests.

--- a/docs/format-options.md
+++ b/docs/format-options.md
@@ -1,0 +1,74 @@
+# proto-confluent format options
+
+Options for the `proto-confluent` Flink Table format. Prefix each with the role
+namespace in `CREATE TABLE` — e.g. `value.proto-confluent.url` or
+`key.proto-confluent.url`.
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `url` | *(required)* | Confluent Schema Registry URL (fallback key: `schema-registry.url`). |
+| `topic` | *(required)* | Kafka topic used to derive the schema subject (`<topic>-key` / `<topic>-value`). |
+| `is_key` | `false` | Whether this format instance encodes/decodes the Kafka key. Set `true` on a `key.format`. |
+| `message-class` | *(none)* | Fully-qualified generated protobuf message class used for serialization and schema registration instead of a dynamic (Row-derived) schema. Applies to the key when `is_key` is `true` and to the value otherwise. |
+| `auto-register-schemas` | `false` | Register the schema with the registry on write. |
+| `normalize-schemas` | `true` | Normalize schemas before registration/lookup. |
+| `use-schema-id` | `-1` | Fixed schema ID for serialization (`-1` = auto). |
+| `skip-known-types` | `true` | Skip well-known types during schema handling. |
+| `on-deserialize-error` | `fail` | `fail` (throw and fail the task) or `skip` (log, count, drop the poison record). |
+| `dead-letter-topic` | *(none)* | Topic that receives raw bytes of records that fail to deserialize. |
+
+SSL (`ssl.keystore.*`, `ssl.truststore.*`), auth (`basic-auth.*`,
+`bearer-auth.*`), `properties`, and `dead-letter.properties` are also supported.
+
+## Explicit key and value message classes
+
+By default a sink derives a **dynamic** protobuf schema from the Flink `Row`
+type. To instead pin an **explicit named entity** (a generated protobuf message
+class) for the key and/or the value, set `message-class` on the corresponding
+format. The format registers and serializes with that message's descriptor, so
+downstream consumers can read the topic with a specific (strongly typed)
+protobuf type.
+
+```sql
+CREATE TABLE keyed_sink (
+  `k_id`      STRING,   -- key column (prefixed)
+  `payload`   STRING,   -- value columns
+  `event_ts`  STRING
+) WITH (
+  'connector' = 'kafka',
+  'topic' = 'orders',
+  'properties.bootstrap.servers' = 'kafka:9092',
+
+  -- Key: explicit named message class
+  'key.format' = 'proto-confluent',
+  'key.fields' = 'k_id',
+  'key.fields-prefix' = 'k_',
+  'key.proto-confluent.url' = 'http://schema-registry:8081',
+  'key.proto-confluent.topic' = 'orders',
+  'key.proto-confluent.is_key' = 'true',
+  'key.proto-confluent.auto-register-schemas' = 'true',
+  'key.proto-confluent.message-class' = 'com.example.OrderProto$OrderKey',
+
+  -- Value: explicit named message class
+  'value.format' = 'proto-confluent',
+  'value.fields-include' = 'EXCEPT_KEY',
+  'value.proto-confluent.url' = 'http://schema-registry:8081',
+  'value.proto-confluent.topic' = 'orders',
+  'value.proto-confluent.is_key' = 'false',
+  'value.proto-confluent.auto-register-schemas' = 'true',
+  'value.proto-confluent.message-class' = 'com.example.OrderProto$Order'
+)
+```
+
+Notes:
+
+- `message-class` is role-scoped by `is_key`: on a `key.format`
+  (`is_key = true`) it sets the key message class; on a `value.format` it sets
+  the value message class.
+- Use `key.fields-prefix` when the same protobuf message backs both the key and
+  the value, so the prefixed key columns still map to the proto field names once
+  the prefix is stripped.
+- When `message-class` is unset the format keeps the previous dynamic-schema
+  behavior.
+- The class name is the JVM binary name — nested/generated message classes use
+  `$` (e.g. `com.example.OrderProto$Order`).

--- a/src/integration-test/java/com/bbrownsound/flink/formats/proto/registry/confluent/ProtoConfluentMiniClusterIntegrationTest.java
+++ b/src/integration-test/java/com/bbrownsound/flink/formats/proto/registry/confluent/ProtoConfluentMiniClusterIntegrationTest.java
@@ -379,27 +379,32 @@ class ProtoConfluentMiniClusterIntegrationTest {
             + ")";
     tableEnv.executeSql(createSink);
 
-    tableEnv.executeSql("INSERT INTO simple_sink SELECT * FROM simple_src");
+    org.apache.flink.table.api.TableResult insertResult =
+        tableEnv.executeSql("INSERT INTO simple_sink SELECT * FROM simple_src");
 
-    await()
-        .atMost(90, SECONDS)
-        .pollInterval(Duration.ofSeconds(2))
-        .until(
-            () -> {
-              List<DynamicMessage> consumed = consumeAsDynamicMessage(sinkTopic, bootstrapForJob);
-              return consumed.size() >= 2;
-            });
+    try {
+      await()
+          .atMost(90, SECONDS)
+          .pollInterval(Duration.ofSeconds(2))
+          .until(
+              () -> {
+                List<DynamicMessage> consumed = consumeAsDynamicMessage(sinkTopic, bootstrapForJob);
+                return consumed.size() >= 2;
+              });
 
-    List<DynamicMessage> messages = consumeAsDynamicMessage(sinkTopic, bootstrapForJob);
-    assertTrue(messages.size() >= 2, "Expected at least 2 messages; got " + messages.size());
-    DynamicMessage first = messages.get(0);
-    assertEquals(
-        "hello",
-        first.getField(first.getDescriptorForType().findFieldByName("content")).toString());
-    assertEquals(
-        "2025-01-01",
-        first.getField(first.getDescriptorForType().findFieldByName("date_time")).toString());
-    log("sinkDynamicSchema: done");
+      List<DynamicMessage> messages = consumeAsDynamicMessage(sinkTopic, bootstrapForJob);
+      assertTrue(messages.size() >= 2, "Expected at least 2 messages; got " + messages.size());
+      DynamicMessage first = messages.get(0);
+      assertEquals(
+          "hello",
+          first.getField(first.getDescriptorForType().findFieldByName("content")).toString());
+      assertEquals(
+          "2025-01-01",
+          first.getField(first.getDescriptorForType().findFieldByName("date_time")).toString());
+      log("sinkDynamicSchema: done");
+    } finally {
+      cancelQuietly(insertResult);
+    }
   }
 
   /**
@@ -471,24 +476,317 @@ class ProtoConfluentMiniClusterIntegrationTest {
             + ")";
     tableEnv.executeSql(createSink);
 
-    tableEnv.executeSql("INSERT INTO simple_sink SELECT * FROM simple_src");
+    org.apache.flink.table.api.TableResult insertResult =
+        tableEnv.executeSql("INSERT INTO simple_sink SELECT * FROM simple_src");
 
-    await()
-        .atMost(90, SECONDS)
-        .pollInterval(Duration.ofSeconds(2))
-        .until(
-            () -> {
-              List<TestSimple.SimpleMessage> consumed =
-                  consumeAsSimpleMessage(sinkTopic, bootstrapForJob);
-              return consumed.size() >= 2;
+    try {
+      await()
+          .atMost(90, SECONDS)
+          .pollInterval(Duration.ofSeconds(2))
+          .until(
+              () -> {
+                List<TestSimple.SimpleMessage> consumed =
+                    consumeAsSimpleMessage(sinkTopic, bootstrapForJob);
+                return consumed.size() >= 2;
+              });
+
+      List<TestSimple.SimpleMessage> messages = consumeAsSimpleMessage(sinkTopic, bootstrapForJob);
+      assertTrue(messages.size() >= 2, "Expected at least 2 messages; got " + messages.size());
+      TestSimple.SimpleMessage first = messages.get(0);
+      assertEquals("hello", first.getContent());
+      assertEquals("2025-01-01", first.getDateTime());
+      log("sinkWithMessageClass: done");
+    } finally {
+      cancelQuietly(insertResult);
+    }
+  }
+
+  /**
+   * Source with a strongly typed proto key AND value: produce records whose key and value are both
+   * SimpleMessage protos, then read them through a Flink table that declares 'key.format' and
+   * 'value.format' as proto-confluent. Verifies the strongly typed key is parsed into the prefixed
+   * key columns alongside the value columns. Covers GitHub issue #4.
+   */
+  @Test
+  void keyedSource_readsProtoKeyAndValue() throws Exception {
+    String keyedTopic = "integration-keyed-src";
+    String bootstrapForJob =
+        bootstrapServers.startsWith("PLAINTEXT://")
+            ? bootstrapServers.substring("PLAINTEXT://".length())
+            : bootstrapServers;
+    createTopic(keyedTopic, bootstrapForJob);
+    produceKeyedMessages(keyedTopic, bootstrapForJob);
+
+    String collectKey = "keyedSelect";
+    ConcurrentLinkedQueue<Row> collectedRows = new ConcurrentLinkedQueue<>();
+    COLLECT_SINK_REGISTRY.put(collectKey, collectedRows);
+    try {
+      StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+      env.setParallelism(1);
+      StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
+
+      // key.fields-prefix strips 'k_' before the key format sees the columns, so the key format's
+      // Row type is (content, date_time) and matches the SimpleMessage descriptor by field name.
+      String createTable =
+          "CREATE TABLE keyed_src ("
+              + "  `k_content` STRING,"
+              + "  `k_date_time` STRING,"
+              + "  `content` STRING,"
+              + "  `date_time` STRING"
+              + ") WITH ("
+              + "  'connector' = 'kafka',"
+              + "  'topic' = '"
+              + keyedTopic
+              + "',"
+              + "  'properties.bootstrap.servers' = '"
+              + bootstrapForJob
+              + "',"
+              + "  'scan.startup.mode' = 'earliest-offset',"
+              + "  'key.format' = 'proto-confluent',"
+              + "  'key.fields' = 'k_content;k_date_time',"
+              + "  'key.fields-prefix' = 'k_',"
+              + "  'key.proto-confluent.url' = '"
+              + schemaRegistryUrl
+              + "',"
+              + "  'key.proto-confluent.topic' = '"
+              + keyedTopic
+              + "',"
+              + "  'key.proto-confluent.is_key' = 'true',"
+              + "  'value.format' = 'proto-confluent',"
+              + "  'value.fields-include' = 'EXCEPT_KEY',"
+              + "  'value.proto-confluent.url' = '"
+              + schemaRegistryUrl
+              + "',"
+              + "  'value.proto-confluent.topic' = '"
+              + keyedTopic
+              + "',"
+              + "  'value.proto-confluent.is_key' = 'false'"
+              + ")";
+      tableEnv.executeSql(createTable);
+
+      Table table = tableEnv.from("keyed_src");
+      tableEnv.toDataStream(table).addSink(new CollectSink(collectKey)).name("collect-keyed");
+
+      JobClient jobClient = env.executeAsync("Proto-confluent keyed SELECT");
+      await()
+          .atMost(90, SECONDS)
+          .pollInterval(Duration.ofSeconds(2))
+          .until(() -> collectedRows.size() >= 2);
+      jobClient.cancel();
+      try {
+        jobClient.getJobExecutionResult().get(30, TimeUnit.SECONDS);
+      } catch (ExecutionException e) {
+        if (!(e.getCause() instanceof JobCancellationException)) {
+          throw e;
+        }
+      }
+
+      List<Row> rows = new ArrayList<>(collectedRows);
+      assertTrue(rows.size() >= 2, "Expected at least 2 keyed rows; got " + rows.size());
+      Row first = rows.get(0);
+      // Columns: k_content, k_date_time (from the proto key), content, date_time (from the value).
+      assertEquals("key-hello", first.getField(0).toString());
+      assertEquals("2025-07-01", first.getField(1).toString());
+      assertEquals("hello", first.getField(2).toString());
+      assertEquals("2025-01-01", first.getField(3).toString());
+      log("keyedSource: done");
+    } finally {
+      COLLECT_SINK_REGISTRY.remove(collectKey);
+    }
+  }
+
+  /**
+   * Sink pinning an explicit key message class via 'key.proto-confluent.message-class'. Flink
+   * writes the key using the named SimpleMessage entity (not a dynamic schema); the consumer
+   * deserializes the key as SPECIFIC_PROTOBUF_KEY_TYPE=SimpleMessage and verifies typed accessors.
+   * Covers GitHub issue #20.
+   */
+  @Test
+  void sinkWithKeyMessageClass_keyConsumableAsSimpleMessage() throws Exception {
+    String sinkTopic = "integration-keyed-sink-message-class";
+    String bootstrapForJob =
+        bootstrapServers.startsWith("PLAINTEXT://")
+            ? bootstrapServers.substring("PLAINTEXT://".length())
+            : bootstrapServers;
+    createTopic(sinkTopic, bootstrapForJob);
+    produceTwoMessagesToTopic(TOPIC, bootstrapForJob);
+
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.setParallelism(1);
+    StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
+
+    String createSrc =
+        "CREATE TABLE simple_src_for_keyed_sink ("
+            + "  `content` STRING,"
+            + "  `date_time` STRING"
+            + ") WITH ("
+            + "  'connector' = 'kafka',"
+            + "  'topic' = '"
+            + TOPIC
+            + "',"
+            + "  'properties.bootstrap.servers' = '"
+            + bootstrapForJob
+            + "',"
+            + "  'scan.startup.mode' = 'earliest-offset',"
+            + "  'value.format' = 'proto-confluent',"
+            + "  'value.proto-confluent.url' = '"
+            + schemaRegistryUrl
+            + "',"
+            + "  'value.proto-confluent.topic' = '"
+            + TOPIC
+            + "',"
+            + "  'value.proto-confluent.is_key' = 'false'"
+            + ")";
+    tableEnv.executeSql(createSrc);
+
+    String createSink =
+        "CREATE TABLE keyed_sink ("
+            + "  `k_content` STRING,"
+            + "  `k_date_time` STRING,"
+            + "  `content` STRING,"
+            + "  `date_time` STRING"
+            + ") WITH ("
+            + "  'connector' = 'kafka',"
+            + "  'topic' = '"
+            + sinkTopic
+            + "',"
+            + "  'properties.bootstrap.servers' = '"
+            + bootstrapForJob
+            + "',"
+            + "  'key.format' = 'proto-confluent',"
+            + "  'key.fields' = 'k_content;k_date_time',"
+            + "  'key.fields-prefix' = 'k_',"
+            + "  'key.proto-confluent.url' = '"
+            + schemaRegistryUrl
+            + "',"
+            + "  'key.proto-confluent.topic' = '"
+            + sinkTopic
+            + "',"
+            + "  'key.proto-confluent.auto-register-schemas' = 'true',"
+            + "  'key.proto-confluent.is_key' = 'true',"
+            + "  'key.proto-confluent.message-class' = '"
+            + TestSimple.SimpleMessage.class.getName()
+            + "',"
+            + "  'value.format' = 'proto-confluent',"
+            + "  'value.fields-include' = 'EXCEPT_KEY',"
+            + "  'value.proto-confluent.url' = '"
+            + schemaRegistryUrl
+            + "',"
+            + "  'value.proto-confluent.topic' = '"
+            + sinkTopic
+            + "',"
+            + "  'value.proto-confluent.auto-register-schemas' = 'true',"
+            + "  'value.proto-confluent.is_key' = 'false'"
+            + ")";
+    tableEnv.executeSql(createSink);
+
+    // Capture the streaming INSERT job so it can be cancelled: the shared MiniCluster has only 2
+    // task slots, so a leaked (never-cancelled) sink job would starve later tests of slots.
+    org.apache.flink.table.api.TableResult insertResult =
+        tableEnv.executeSql(
+            "INSERT INTO keyed_sink SELECT content, date_time, content, date_time "
+                + "FROM simple_src_for_keyed_sink");
+
+    try {
+      await()
+          .atMost(90, SECONDS)
+          .pollInterval(Duration.ofSeconds(2))
+          .until(() -> consumeKeyAsSimpleMessage(sinkTopic, bootstrapForJob).size() >= 2);
+
+      List<TestSimple.SimpleMessage> keys = consumeKeyAsSimpleMessage(sinkTopic, bootstrapForJob);
+      assertTrue(keys.size() >= 2, "Expected at least 2 keys; got " + keys.size());
+      TestSimple.SimpleMessage firstKey = keys.get(0);
+      assertEquals("hello", firstKey.getContent());
+      assertEquals("2025-01-01", firstKey.getDateTime());
+      log("sinkWithKeyMessageClass: done");
+    } finally {
+      cancelQuietly(insertResult);
+    }
+  }
+
+  private static void cancelQuietly(org.apache.flink.table.api.TableResult result) {
+    result
+        .getJobClient()
+        .ifPresent(
+            jc -> {
+              try {
+                jc.cancel().get(30, TimeUnit.SECONDS);
+              } catch (InterruptedException
+                  | ExecutionException
+                  | java.util.concurrent.TimeoutException e) {
+                LOG.warn("[MiniClusterIT] failed to cancel job cleanly", e);
+              }
             });
+  }
 
-    List<TestSimple.SimpleMessage> messages = consumeAsSimpleMessage(sinkTopic, bootstrapForJob);
-    assertTrue(messages.size() >= 2, "Expected at least 2 messages; got " + messages.size());
-    TestSimple.SimpleMessage first = messages.get(0);
-    assertEquals("hello", first.getContent());
-    assertEquals("2025-01-01", first.getDateTime());
-    log("sinkWithMessageClass: done");
+  private void produceKeyedMessages(String topic, String bootstrapForJob) throws Exception {
+    Map<String, Object> producerConfig =
+        Map.<String, Object>of(
+            "bootstrap.servers",
+            bootstrapForJob,
+            "key.serializer",
+            KafkaProtobufSerializer.class.getName(),
+            "value.serializer",
+            KafkaProtobufSerializer.class.getName(),
+            "schema.registry.url",
+            schemaRegistryUrl,
+            "auto.register.schemas",
+            "true");
+    try (KafkaProducer<TestSimple.SimpleMessage, TestSimple.SimpleMessage> producer =
+        new KafkaProducer<>(producerConfig)) {
+      producer
+          .send(
+              new ProducerRecord<>(
+                  topic,
+                  TestSimple.SimpleMessage.newBuilder()
+                      .setContent("key-hello")
+                      .setDateTime("2025-07-01")
+                      .build(),
+                  TestSimple.SimpleMessage.newBuilder()
+                      .setContent("hello")
+                      .setDateTime("2025-01-01")
+                      .build()))
+          .get(10, SECONDS);
+      producer
+          .send(
+              new ProducerRecord<>(
+                  topic,
+                  TestSimple.SimpleMessage.newBuilder()
+                      .setContent("key-world")
+                      .setDateTime("2025-07-02")
+                      .build(),
+                  TestSimple.SimpleMessage.newBuilder()
+                      .setContent("world")
+                      .setDateTime("2025-01-02")
+                      .build()))
+          .get(10, SECONDS);
+      producer.flush();
+    }
+  }
+
+  private List<TestSimple.SimpleMessage> consumeKeyAsSimpleMessage(String topic, String bootstrap) {
+    Map<String, Object> props = new java.util.HashMap<>();
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrap);
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, "key-specific-" + UUID.randomUUID());
+    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, KafkaProtobufDeserializer.class);
+    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaProtobufDeserializer.class);
+    props.put(KafkaProtobufDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl);
+    props.put(
+        KafkaProtobufDeserializerConfig.SPECIFIC_PROTOBUF_KEY_TYPE,
+        TestSimple.SimpleMessage.class.getName());
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    List<TestSimple.SimpleMessage> out = new ArrayList<>();
+    try (KafkaConsumer<TestSimple.SimpleMessage, DynamicMessage> consumer =
+        new KafkaConsumer<>(props)) {
+      consumer.subscribe(Collections.singletonList(topic));
+      ConsumerRecords<TestSimple.SimpleMessage, DynamicMessage> records =
+          consumer.poll(Duration.ofMillis(5000));
+      records.forEach(
+          r -> {
+            if (r.key() != null) out.add(r.key());
+          });
+    }
+    return out;
   }
 
   private void createTopic(String topic, String bootstrapForJob) throws Exception {

--- a/src/main/java/com/bbrownsound/flink/formats/proto/registry/confluent/ProtoConfluentFormatOptions.java
+++ b/src/main/java/com/bbrownsound/flink/formats/proto/registry/confluent/ProtoConfluentFormatOptions.java
@@ -34,6 +34,24 @@ public class ProtoConfluentFormatOptions {
           .withFallbackKeys("is_key")
           .withDescription("is this format used on a kafka key, default false");
 
+  /**
+   * Fully-qualified generated protobuf message class used to serialize/register instead of a
+   * dynamic (Row-derived) schema.
+   */
+  public static final ConfigOption<String> MESSAGE_CLASS =
+      ConfigOptions.key("message-class")
+          .stringType()
+          .noDefaultValue()
+          .withFallbackKeys("message_class")
+          .withDescription(
+              "Fully-qualified generated protobuf message class (e.g. "
+                  + "'com.example.MyProto$MyMessage') to use for serialization and schema "
+                  + "registration. When set, the format serializes with this named message's "
+                  + "descriptor instead of deriving a dynamic schema from the Flink Row type. "
+                  + "Applies to the key when 'is_key' is true and to the value otherwise, so a "
+                  + "sink can pin an explicit named entity for its key and/or value. When unset, "
+                  + "the format falls back to the previous dynamic-schema behavior.");
+
   /** Whether to auto-register schemas. */
   public static final ConfigOption<Boolean> AUTO_REGISTER_SCHEMAS =
       ConfigOptions.key("auto-register-schemas")

--- a/src/main/java/com/bbrownsound/flink/formats/proto/registry/confluent/RegistryProtoFormatFactory.java
+++ b/src/main/java/com/bbrownsound/flink/formats/proto/registry/confluent/RegistryProtoFormatFactory.java
@@ -60,6 +60,7 @@ public class RegistryProtoFormatFactory
             ProtoConfluentFormatOptions.URL,
             ProtoConfluentFormatOptions.TOPIC,
             ProtoConfluentFormatOptions.IS_KEY,
+            ProtoConfluentFormatOptions.MESSAGE_CLASS,
             ProtoConfluentFormatOptions.PROPERTIES,
             ProtoConfluentFormatOptions.SSL_KEYSTORE_LOCATION,
             ProtoConfluentFormatOptions.SSL_KEYSTORE_PASSWORD,
@@ -87,6 +88,7 @@ public class RegistryProtoFormatFactory
   public Set<ConfigOption<?>> optionalOptions() {
     Set<ConfigOption<?>> options = new HashSet<>();
     options.add(ProtoConfluentFormatOptions.IS_KEY);
+    options.add(ProtoConfluentFormatOptions.MESSAGE_CLASS);
     options.add(ProtoConfluentFormatOptions.PROPERTIES);
     options.add(ProtoConfluentFormatOptions.AUTO_REGISTER_SCHEMAS);
     options.add(ProtoConfluentFormatOptions.NORMALIZE_SCHEMAS);

--- a/src/main/java/com/bbrownsound/flink/formats/proto/registry/confluent/config/ProtoConfluentFormatConfig.java
+++ b/src/main/java/com/bbrownsound/flink/formats/proto/registry/confluent/config/ProtoConfluentFormatConfig.java
@@ -86,6 +86,16 @@ public class ProtoConfluentFormatConfig implements Serializable {
   properties.put("normalize.schemas", normalize.toString());
   properties.put("use.schema.id", schemaId.toString());
   properties.put("skip.known.types", skipKnown.toString());
+    // An explicit message-class is role-scoped: route it to the key or value serializer property
+    // based on is_key so the serializer picks it up. A value already tunneled in via the raw
+    // 'properties' map (e.g. 'value.message-class:...') is preserved when this option is unset.
+    formatOptions
+        .getOptional(ProtoConfluentFormatOptions.MESSAGE_CLASS)
+        .filter(v -> !v.isEmpty())
+        .ifPresent(
+            v ->
+                properties.put(
+                    Boolean.TRUE.equals(isKey) ? "key.message-class" : "value.message-class", v));
     LOG.debug(
         "[proto-confluent] FormatConfig from options: schemaRegistryURL={}, topic={}, "
             + "isKey={}, propertiesKeys={}",

--- a/src/main/java/com/bbrownsound/flink/formats/proto/registry/confluent/serialize/RowDataProtoSerializer.java
+++ b/src/main/java/com/bbrownsound/flink/formats/proto/registry/confluent/serialize/RowDataProtoSerializer.java
@@ -28,13 +28,26 @@ import org.slf4j.LoggerFactory;
 public class RowDataProtoSerializer extends KafkaProtobufSerializer<DynamicMessage> {
   private static final Logger LOG = LoggerFactory.getLogger(RowDataProtoSerializer.class);
 
-  /** Config key for optional specific Protobuf message class (e.g. for schema registration). */
+  /**
+   * Config key for an explicit Protobuf message class used when this serializer encodes the value
+   * (i.e. {@code isKey == false}), e.g. for schema registration.
+   */
   public static final String VALUE_MESSAGE_CLASS_CONFIG = "value.message-class";
+
+  /**
+   * Config key for an explicit Protobuf message class used when this serializer encodes the key
+   * (i.e. {@code isKey == true}). Companion to {@link #VALUE_MESSAGE_CLASS_CONFIG} so a Kafka sink
+   * can pin an explicit named entity for its key instead of a dynamic schema.
+   */
+  public static final String KEY_MESSAGE_CLASS_CONFIG = "key.message-class";
 
   private final Map<String, RowDataToProtoConverters.RowDataToProtoConverter> converters;
   private final Map<String, Descriptors.Descriptor> schemaCache;
 
-  /** When set via {@value #VALUE_MESSAGE_CLASS_CONFIG}, used for serialization and registration. */
+  /**
+   * When set via {@value #KEY_MESSAGE_CLASS_CONFIG} (key) or {@value #VALUE_MESSAGE_CLASS_CONFIG}
+   * (value), used for serialization and registration in place of a dynamic schema.
+   */
   private volatile Descriptors.Descriptor messageClassDescriptor;
 
   RowDataProtoSerializer(SchemaRegistryClient client) {
@@ -46,19 +59,23 @@ public class RowDataProtoSerializer extends KafkaProtobufSerializer<DynamicMessa
   @Override
   public void configure(Map<String, ?> configs, boolean isKey) {
     super.configure(configs, isKey);
-    Object messageClassObj = configs.get(VALUE_MESSAGE_CLASS_CONFIG);
+    // A single format instance serves either the key or the value, so select the matching config
+    // key. This keeps key and value message classes independent for a table that pins both.
+    String configKey = isKey ? KEY_MESSAGE_CLASS_CONFIG : VALUE_MESSAGE_CLASS_CONFIG;
+    Object messageClassObj = configs.get(configKey);
     if (messageClassObj instanceof String) {
       String className = (String) messageClassObj;
       if (!className.isEmpty()) {
         try {
           this.messageClassDescriptor = descriptorFromMessageClass(className);
           LOG.info(
-              "[proto-confluent] Using message class for serialization: {} -> {}",
+              "[proto-confluent] Using message class for {} serialization: {} -> {}",
+              isKey ? "key" : "value",
               className,
               messageClassDescriptor.getFullName());
         } catch (Exception e) {
           throw new ValidationException(
-              "Failed to resolve descriptor for value.message-class=" + className, e);
+              "Failed to resolve descriptor for " + configKey + "=" + className, e);
         }
       }
     }

--- a/src/test/java/com/bbrownsound/flink/formats/proto/registry/confluent/RegistryProtoFormatFactoryTest.java
+++ b/src/test/java/com/bbrownsound/flink/formats/proto/registry/confluent/RegistryProtoFormatFactoryTest.java
@@ -45,6 +45,18 @@ class RegistryProtoFormatFactoryTest {
   }
 
   @Test
+  void optionalOptions_containsMessageClass() {
+    var optional = factory.optionalOptions();
+    assertTrue(optional.stream().anyMatch(o -> o.key().equals("message-class")));
+  }
+
+  @Test
+  void forwardOptions_containsMessageClass() {
+    var forward = factory.forwardOptions();
+    assertTrue(forward.stream().anyMatch(o -> o.key().equals("message-class")));
+  }
+
+  @Test
   void buildOptionalPropertiesMap_empty() {
     Configuration options = new Configuration();
     options.set(ProtoConfluentFormatOptions.URL, "http://localhost:8081");

--- a/src/test/java/com/bbrownsound/flink/formats/proto/registry/confluent/config/ProtoConfluentFormatConfigTest.java
+++ b/src/test/java/com/bbrownsound/flink/formats/proto/registry/confluent/config/ProtoConfluentFormatConfigTest.java
@@ -6,6 +6,7 @@ import org.apache.flink.configuration.Configuration;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
@@ -53,5 +54,50 @@ class ProtoConfluentFormatConfigTest {
     assertTrue(config.isKey);
     assertEquals("true", config.getProperties().get("auto.register.schemas"));
     assertEquals("false", config.getProperties().get("normalize.schemas"));
+  }
+
+  @Test
+  void messageClass_routedToValueProperty_whenNotKey() {
+    Configuration options = new Configuration();
+    options.set(ProtoConfluentFormatOptions.URL, "http://sr:8081");
+    options.set(ProtoConfluentFormatOptions.TOPIC, "events");
+    options.set(ProtoConfluentFormatOptions.IS_KEY, false);
+    options.set(ProtoConfluentFormatOptions.MESSAGE_CLASS, "com.example.Foo$Bar");
+    ProtoConfluentFormatConfig config = new ProtoConfluentFormatConfig(options);
+    assertEquals("com.example.Foo$Bar", config.getProperties().get("value.message-class"));
+    assertNull(config.getProperties().get("key.message-class"));
+  }
+
+  @Test
+  void messageClass_routedToKeyProperty_whenKey() {
+    Configuration options = new Configuration();
+    options.set(ProtoConfluentFormatOptions.URL, "http://sr:8081");
+    options.set(ProtoConfluentFormatOptions.TOPIC, "events");
+    options.set(ProtoConfluentFormatOptions.IS_KEY, true);
+    options.set(ProtoConfluentFormatOptions.MESSAGE_CLASS, "com.example.Foo$Bar");
+    ProtoConfluentFormatConfig config = new ProtoConfluentFormatConfig(options);
+    assertEquals("com.example.Foo$Bar", config.getProperties().get("key.message-class"));
+    assertNull(config.getProperties().get("value.message-class"));
+  }
+
+  @Test
+  void messageClass_absentByDefault() {
+    Configuration options = new Configuration();
+    options.set(ProtoConfluentFormatOptions.URL, "http://sr:8081");
+    options.set(ProtoConfluentFormatOptions.TOPIC, "events");
+    ProtoConfluentFormatConfig config = new ProtoConfluentFormatConfig(options);
+    assertNull(config.getProperties().get("value.message-class"));
+    assertNull(config.getProperties().get("key.message-class"));
+  }
+
+  @Test
+  void messageClass_emptyValueIgnored() {
+    Configuration options = new Configuration();
+    options.set(ProtoConfluentFormatOptions.URL, "http://sr:8081");
+    options.set(ProtoConfluentFormatOptions.TOPIC, "events");
+    options.set(ProtoConfluentFormatOptions.MESSAGE_CLASS, "");
+    ProtoConfluentFormatConfig config = new ProtoConfluentFormatConfig(options);
+    assertNull(config.getProperties().get("value.message-class"));
+    assertNull(config.getProperties().get("key.message-class"));
   }
 }

--- a/src/test/java/com/bbrownsound/flink/formats/proto/registry/confluent/config/ProtoConfluentFormatConfigTest.java
+++ b/src/test/java/com/bbrownsound/flink/formats/proto/registry/confluent/config/ProtoConfluentFormatConfigTest.java
@@ -91,6 +91,38 @@ class ProtoConfluentFormatConfigTest {
   }
 
   @Test
+  void messageClass_typedOptionWinsOverTunneledProperty() {
+    // Both a raw tunneled 'value.message-class' (via properties) and the typed MESSAGE_CLASS
+    // option are set. The typed option must win — locks the precedence contract so a future
+    // reorder of the puts in ProtoConfluentFormatConfig can't flip it silently.
+    Configuration options = new Configuration();
+    options.set(ProtoConfluentFormatOptions.URL, "http://sr:8081");
+    options.set(ProtoConfluentFormatOptions.TOPIC, "events");
+    options.set(ProtoConfluentFormatOptions.IS_KEY, false);
+    options.set(
+        ProtoConfluentFormatOptions.PROPERTIES,
+        Map.of("value.message-class", "com.example.Tunneled$Old"));
+    options.set(ProtoConfluentFormatOptions.MESSAGE_CLASS, "com.example.Typed$New");
+    ProtoConfluentFormatConfig config = new ProtoConfluentFormatConfig(options);
+    assertEquals("com.example.Typed$New", config.getProperties().get("value.message-class"));
+  }
+
+  @Test
+  void messageClass_tunneledPropertyPreserved_whenTypedOptionUnset() {
+    // The raw 'value.message-class' tunnel is the path existing consumers rely on; it must survive
+    // untouched when the typed MESSAGE_CLASS option is not set.
+    Configuration options = new Configuration();
+    options.set(ProtoConfluentFormatOptions.URL, "http://sr:8081");
+    options.set(ProtoConfluentFormatOptions.TOPIC, "events");
+    options.set(ProtoConfluentFormatOptions.IS_KEY, false);
+    options.set(
+        ProtoConfluentFormatOptions.PROPERTIES,
+        Map.of("value.message-class", "com.example.Tunneled$Old"));
+    ProtoConfluentFormatConfig config = new ProtoConfluentFormatConfig(options);
+    assertEquals("com.example.Tunneled$Old", config.getProperties().get("value.message-class"));
+  }
+
+  @Test
   void messageClass_emptyValueIgnored() {
     Configuration options = new Configuration();
     options.set(ProtoConfluentFormatOptions.URL, "http://sr:8081");

--- a/src/test/java/com/bbrownsound/flink/formats/proto/registry/confluent/serialize/RowDataProtoSerializerTest.java
+++ b/src/test/java/com/bbrownsound/flink/formats/proto/registry/confluent/serialize/RowDataProtoSerializerTest.java
@@ -8,7 +8,9 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.apache.flink.table.api.ValidationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -121,5 +123,106 @@ class RowDataProtoSerializerTest {
     assertTrue(
         mockRegistry.getLatestSchemaMetadata("test-topic-value") != null
             || result.length > 5);
+  }
+
+  @Test
+  void serializeRowData_whenIsKey_registersUnderKeySubjectAndReturnsBytes() throws Exception {
+    MockSchemaRegistryClient keyRegistry =
+        new MockSchemaRegistryClient(Collections.singletonList(new ProtobufSchemaProvider()));
+    RowDataProtoSerializer keySerializer = new RowDataProtoSerializer(keyRegistry);
+    // isKey=true: a strongly typed key must serialize and register under the -key subject.
+    keySerializer.configure(
+        Map.of("schema.registry.url", "http://localhost:8081", "auto.register.schemas", "true"),
+        true);
+
+    GenericRowData row = new GenericRowData(2);
+    row.setField(0, StringData.fromString("key-content"));
+    row.setField(1, StringData.fromString("2025-07-10"));
+
+    byte[] result = keySerializer.serializeRowData("keyed-topic", rowType, row);
+    assertNotNull(result);
+    assertTrue(result.length > 0);
+    assertNotNull(keyRegistry.getLatestSchemaMetadata("keyed-topic-key"));
+  }
+
+  @Test
+  void serializeRowData_whenKeyMessageClassConfigured_usesMessageClassDescriptor()
+      throws Exception {
+    MockSchemaRegistryClient keyRegistry =
+        new MockSchemaRegistryClient(Collections.singletonList(new ProtobufSchemaProvider()));
+    RowDataProtoSerializer keySerializer = new RowDataProtoSerializer(keyRegistry);
+    keySerializer.configure(
+        Map.of(
+            "schema.registry.url",
+            "http://localhost:8081",
+            "auto.register.schemas",
+            "true",
+            RowDataProtoSerializer.KEY_MESSAGE_CLASS_CONFIG,
+            TestSimple.SimpleMessage.class.getName()),
+        true);
+
+    GenericRowData row = new GenericRowData(2);
+    row.setField(0, StringData.fromString("typed-key"));
+    row.setField(1, StringData.fromString("2025-07-10"));
+
+    byte[] result = keySerializer.serializeRowData("keyed-topic", rowType, row);
+    assertNotNull(result);
+    assertTrue(result.length > 0);
+    // The explicit key message class registers the SimpleMessage schema under the -key subject.
+    ProtobufSchema registered =
+        (ProtobufSchema)
+            keyRegistry.getSchemaById(
+                keyRegistry.getLatestSchemaMetadata("keyed-topic-key").getId());
+    assertTrue(registered.toDescriptor().getFullName().endsWith("SimpleMessage"));
+  }
+
+  @Test
+  void configure_whenKeyMessageClassOnlyApplies_whenIsKey() throws Exception {
+    // value.message-class must be ignored for a key serializer; only key.message-class applies.
+    MockSchemaRegistryClient keyRegistry =
+        new MockSchemaRegistryClient(Collections.singletonList(new ProtobufSchemaProvider()));
+    RowDataProtoSerializer keySerializer = new RowDataProtoSerializer(keyRegistry);
+    keySerializer.configure(
+        Map.of(
+            "schema.registry.url",
+            "http://localhost:8081",
+            "auto.register.schemas",
+            "true",
+            // Deliberately set only the VALUE key with a bogus class: a key serializer must not
+            // read it, so configure() must not throw and serialization falls back to dynamic.
+            RowDataProtoSerializer.VALUE_MESSAGE_CLASS_CONFIG,
+            "not.a.real.Class"),
+        true);
+
+    GenericRowData row = new GenericRowData(2);
+    row.setField(0, StringData.fromString("a"));
+    row.setField(1, StringData.fromString("b"));
+    byte[] result = keySerializer.serializeRowData("keyed-topic", rowType, row);
+    assertNotNull(result);
+    assertTrue(result.length > 0);
+  }
+
+  @Test
+  void configure_whenKeyMessageClassInvalid_throwsValidationException() {
+    RowDataProtoSerializer badSerializer = new RowDataProtoSerializer(schemaRegistryClient);
+    Map<String, Object> configs =
+        Map.of(
+            "schema.registry.url",
+            "http://localhost:8081",
+            RowDataProtoSerializer.KEY_MESSAGE_CLASS_CONFIG,
+            "com.example.DoesNotExist");
+    assertThrows(ValidationException.class, () -> badSerializer.configure(configs, true));
+  }
+
+  @Test
+  void configure_whenValueMessageClassInvalid_throwsValidationException() {
+    RowDataProtoSerializer badSerializer = new RowDataProtoSerializer(schemaRegistryClient);
+    Map<String, Object> configs =
+        Map.of(
+            "schema.registry.url",
+            "http://localhost:8081",
+            RowDataProtoSerializer.VALUE_MESSAGE_CLASS_CONFIG,
+            "com.example.DoesNotExist");
+    assertThrows(ValidationException.class, () -> badSerializer.configure(configs, false));
   }
 }

--- a/src/test/java/com/bbrownsound/flink/formats/proto/registry/confluent/serialize/RowDataProtoSerializerTest.java
+++ b/src/test/java/com/bbrownsound/flink/formats/proto/registry/confluent/serialize/RowDataProtoSerializerTest.java
@@ -119,10 +119,12 @@ class RowDataProtoSerializerTest {
         serializerWithMessageClass.serializeRowData("test-topic", rowType, row);
     assertNotNull(result);
     assertTrue(result.length > 0);
-    // Schema should be registered under topic-value with SimpleMessage descriptor
-    assertTrue(
-        mockRegistry.getLatestSchemaMetadata("test-topic-value") != null
-            || result.length > 5);
+    // The explicit value message class registers the SimpleMessage schema under the -value subject.
+    ProtobufSchema registered =
+        (ProtobufSchema)
+            mockRegistry.getSchemaById(
+                mockRegistry.getLatestSchemaMetadata("test-topic-value").getId());
+    assertTrue(registered.toDescriptor().getFullName().endsWith("SimpleMessage"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Implements #20 (explicitly set the message **key** class — companion to the existing value message class) and #4 (test coverage for key- and value-schemed messages, both happy and sad path).

By default a `proto-confluent` sink derives a **dynamic** schema from the Flink `Row` type. This PR adds a first-class `message-class` format option that pins an **explicit named** protobuf message class for serialization/registration. The option is role-scoped by `is_key`, so a sink can pin a named entity for its key and/or value independently.

## Changes

**Main:**
- `ProtoConfluentFormatOptions` — new `message-class` `ConfigOption`.
- `ProtoConfluentFormatConfig` — routes `message-class` to the key or value serializer property based on `is_key`; backward compatible with the existing `value.message-class` tunnel through `properties`.
- `RowDataProtoSerializer` — new `KEY_MESSAGE_CLASS_CONFIG`; `configure()` now selects the key vs value message class by role (`isKey`). Value class is ignored for a key serializer and vice versa.
- `RegistryProtoFormatFactory` — registers `message-class` as optional + forwarded.

**Tests (happy + sad path):**
- Unit — key serialization (dynamic subject `topic-key`, and explicit key message class), role isolation (a bogus `value.message-class` is ignored by a key serializer), and `ValidationException` on an invalid class for **both** key and value; config routing (key/value/empty/absent); factory option presence.
- Integration — a strongly typed proto **key + value** read end-to-end through a Flink table (`key.format` + `value.format` = `proto-confluent`, `key.fields-prefix`), and a keyed sink pinning `key.proto-confluent.message-class` consumed back as a specific `SimpleMessage` key.

**Docs:**
- README pointer + new `docs/format-options.md` with the full option reference and a complete keyed-sink example.

## Verification

Run on JDK 21 (CI toolchain):
- **124 unit tests pass**, 0 failures.
- `spotlessCheck`, `checkstyle` (main/test/integration), `spotbugs` (main/test) all pass.
- Both new integration tests pass; the pre-existing `sinkWithMessageClass` IT is occasionally flaky under parallel container load but passes in isolation (unchanged by this PR).

Closes #20
Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)